### PR TITLE
chore(sb_api_interceptor): remove console logs printing kid filenames

### DIFF
--- a/sb_api_interceptor/index.js
+++ b/sb_api_interceptor/index.js
@@ -88,9 +88,7 @@
                      return reject(err);
                  }
                  kidToPublicKeyMap[filename] = content;
-                 console.log(`${ CONSTANTS.logPrefix } loaded kid: ${ filename }`);
                  if (fileCount === 0) {
-                     console.info("loaded all public key for authentication");
                      useKidBasedValidation = true;
                      resolve();
                  }


### PR DESCRIPTION
Drops the per-key "loaded kid" log and the "loaded all public key for authentication" summary log that ran during offline token public key load. These printed key identifiers to stdout on every startup, which is unnecessary noise in production logs.